### PR TITLE
docs: add google colab links in a README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,17 +5,3 @@ results/
 dist/
 mastml.egg-info/
 .DS_Store
-
-# ignore these, added by avery for local use only; should not be commited
-.husky/
-examples/*.ipynb
-examples/*.py
-examples/dot-py/
-output/
-multiToSingle.py
-drive/
-*.ipynb
-figshare/
-format_class.py
-my_excel_file.xlsx
-plot.png

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,17 @@ results/
 dist/
 mastml.egg-info/
 .DS_Store
+
+# ignore these, added by avery for local use only; should not be commited
+.husky/
+examples/*.ipynb
+examples/*.py
+examples/dot-py/
+output/
+multiToSingle.py
+drive/
+*.ipynb
+figshare/
+format_class.py
+my_excel_file.xlsx
+plot.png

--- a/README.md
+++ b/README.md
@@ -72,3 +72,7 @@ MAST-ML can also be installed via pip:
 ```
 pip install mastml
 ```
+
+## Getting Started
+
+You can start by running some of the example notebooks located in the `example` folder. Click [here](/examples) for more information.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,10 @@
+# Run in Google Colab
+
+You can click the following links to run the example notebooks in google colab.
+
+- [Tutorial 1: Getting Started](https://colab.research.google.com/github/uw-cmg/MAST-ML/blob/master/examples/MASTML_Tutorial_1_GettingStarted.ipynb)
+- [Tutorial 2: Data Import](https://colab.research.google.com/github/uw-cmg/MAST-ML/blob/master/examples/MASTML_Tutorial_2_DataImport.ipynb)
+- [Tutorial 3: Feature Engineering](https://colab.research.google.com/github/uw-cmg/MAST-ML/blob/master/examples/MASTML_Tutorial_3_FeatureEngineering.ipynb)
+- [Tutorial 4: Models and Tests](https://colab.research.google.com/github/uw-cmg/MAST-ML/blob/master/examples/MASTML_Tutorial_4_Models_and_Tests.ipynb)
+- [Tutorial 5: NestedCV and OptimizedModels](https://colab.research.google.com/github/uw-cmg/MAST-ML/blob/master/examples/MASTML_Tutorial_5_NestedCV_and_OptimizedModels.ipynb)
+- [Tutorial 6: ErrorAnalysis Uncertainty Quantification](https://colab.research.google.com/github/uw-cmg/MAST-ML/blob/master/examples/MASTML_Tutorial_6_ErrorAnalysis_UncertaintyQuantification.ipynb)


### PR DESCRIPTION
This adds the google collab links. 

I added it in a README file inside the example folders and added a comment on the main README that points to that. Alternatively, it could just be added directly to the main README.