### PR TITLE
Dissolve for loop that concatanet string to a Python str.join API as …

### DIFF
--- a/mastml/feature_generators.py
+++ b/mastml/feature_generators.py
@@ -244,13 +244,9 @@ class ElementalFeatureGenerator(BaseGenerator):
             # Parse out brackets from compositions
             for comp in compositions_raw:
                 comp_split = comp.split('[')
-                comp_str = ''
-                for s in comp_split:
-                    comp_str += s
+                comp_str = ''.join([s for s in comp_split])
                 comp_split = comp_str.split(']')
-                comp_str = ''
-                for s in comp_split:
-                    comp_str += s
+                comp_str = ''.join([s for s in comp_split])
                 compositions.append(comp_str)
         else:
             compositions = compositions_raw


### PR DESCRIPTION
It is efficient to dissolve for loop that concatenate string to Python's `str.join` API